### PR TITLE
Create Get List of Duplicate Script Include Names

### DIFF
--- a/Prompts/Get List of Duplicate Script Include Names
+++ b/Prompts/Get List of Duplicate Script Include Names
@@ -1,5 +1,6 @@
-print a list of Script Include Names that are duplicated
+Prompt: print a list of Script Include Names that are duplicated
 
+Example output:
 var scriptIncludes = new GlideAggregate('sys_script_include');
 scriptIncludes.addAggregate('COUNT', 'api_name');
 scriptIncludes.addNotNullQuery('api_name');

--- a/Prompts/Get List of Duplicate Script Include Names
+++ b/Prompts/Get List of Duplicate Script Include Names
@@ -1,0 +1,11 @@
+print a list of Script Include Names that are duplicated
+
+var scriptIncludes = new GlideAggregate('sys_script_include');
+scriptIncludes.addAggregate('COUNT', 'api_name');
+scriptIncludes.addNotNullQuery('api_name');
+scriptIncludes.groupBy('api_name');
+scriptIncludes.addHaving('COUNT', '>', 1);
+scriptIncludes.query();
+while (scriptIncludes.next()) {
+	gs.print(scriptIncludes.api_name);
+}


### PR DESCRIPTION
Creates a script that checks Script Include API Names for duplicates, which is technically possible and maddening to troubleshoot when you can't figure out why your script is not running. 