### PR TITLE
Exclusion disclaimer v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![promptlibrary Banner](https://github.com/user-attachments/assets/247f5479-90ce-4928-a15d-dabeab7797d8)
+![promptlibrary Banner](https://github.com/ServiceNowDevProgram/Hacktoberfest/blob/main/images/promptlibrary-excluded.png)
 
 ## ⚠️ Unfortunately this repository got ${\color{red}excluded}$ from Hacktoberfest 2024. ⚠️
 ## As a result, while contributions are still accepted, they will _not count_ towards the completion of Hactoberfest 2024.


### PR DESCRIPTION
Updated the banner image to the one with the Hacktoberfest exclusion, and slightly rephrased and reformatted the disclaimer text.